### PR TITLE
Added ob_stat variable to loop to avoid NameError on IDEs (ga.py and rs.py)

### DIFF
--- a/es_distributed/ga.py
+++ b/es_distributed/ga.py
@@ -1,11 +1,7 @@
-import logging
-import time
-from collections import namedtuple
-
-import numpy as np
-
-from .dist import MasterClient, WorkerClient
 from .es import *
+
+
+GATask = namedtuple('GATask', ['params', 'population', 'ob_mean', 'ob_std', 'timestep_limit'])
 
 
 def setup(exp, single_threaded):
@@ -33,10 +29,9 @@ def rollout_and_update_ob_stat(policy, env, timestep_limit, rs, task_ob_stat, ca
         rollout_rews, rollout_len = policy.rollout(env, timestep_limit=timestep_limit, random_stream=rs)
     return rollout_rews, rollout_len
 
-GATask = namedtuple('GATask', ['params', 'population', 'ob_mean', 'ob_std', 'timestep_limit'])
+
 def run_master(master_redis_cfg, log_dir, exp):
     logger.info('run_master: {}'.format(locals()))
-    from .optimizers import SGD, Adam
     from . import tabular_logger as tlogger
     logger.info('Tabular logging to {}'.format(log_dir))
     tlogger.start(log_dir)
@@ -76,6 +71,12 @@ def run_master(master_redis_cfg, log_dir, exp):
         step_tstart = time.time()
         theta = policy.get_trainable_flat()
         assert theta.dtype == np.float32
+
+        if policy.needs_ob_stat:
+            ob_stat = RunningStat(
+                env.observation_space.shape,
+                eps=1e-2  # eps to prevent dividing by zero at the beginning when computing mean/stdev
+            )
 
         curr_task_id = master.declare_task(GATask(
             params=theta,
@@ -203,6 +204,7 @@ def run_master(master_redis_cfg, log_dir, exp):
             assert not osp.exists(filename)
             policy.save(filename)
             tlogger.log('Saved snapshot {}'.format(filename))
+
 
 def run_worker(master_redis_cfg, relay_redis_cfg, noise, *, min_task_runtime=.2):
     logger.info('run_worker: {}'.format(locals()))

--- a/es_distributed/rs.py
+++ b/es_distributed/rs.py
@@ -1,16 +1,8 @@
-import logging
-import time
-from collections import namedtuple
-
-import numpy as np
-
-from .dist import MasterClient, WorkerClient
 from .ga import *
 
 
 def run_master(master_redis_cfg, log_dir, exp):
     logger.info('run_master: {}'.format(locals()))
-    from .optimizers import SGD, Adam
     from . import tabular_logger as tlogger
     logger.info('Tabular logging to {}'.format(log_dir))
     tlogger.start(log_dir)
@@ -46,6 +38,12 @@ def run_master(master_redis_cfg, log_dir, exp):
         step_tstart = time.time()
         theta = policy.get_trainable_flat()
         assert theta.dtype == np.float32
+
+        if policy.needs_ob_stat:
+            ob_stat = RunningStat(
+                env.observation_space.shape,
+                eps=1e-2  # eps to prevent dividing by zero at the beginning when computing mean/stdev
+            )
 
         curr_task_id = master.declare_task(Task(
             params=theta,
@@ -159,6 +157,7 @@ def run_master(master_redis_cfg, log_dir, exp):
             assert not osp.exists(filename)
             policy.save(filename)
             tlogger.log('Saved snapshot {}'.format(filename))
+
 
 def run_worker(master_redis_cfg, relay_redis_cfg, noise, *, min_task_runtime=.2):
     logger.info('run_worker: {}'.format(locals()))


### PR DESCRIPTION
I was having a bug with `NameError: name 'ob_stat' is not defined` when using either ga.py or rs.py. I'm aware that both ga and rs, due to their policies
```
@property
def needs_ob_stat(self):
     return False
```

never need `ob_stat`. However, if you are running the code from an IDE like Pycharm, it will throw the error regardless. Removed unused imports and added some PEP8 compliance on both files as well to make them easier to read. Thank you very much for open sourcing this code!